### PR TITLE
Parse Environment struct using custom Decodable implementation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,12 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "gh-pr-patrol",
+            dependencies: ["Core"]),
+        .target(
+            name: "Core",
             dependencies: []),
+        .testTarget(
+            name: "CoreTests",
+            dependencies: ["Core"]),
     ]
 )

--- a/Sources/gh-pr-patrol/Environment.swift
+++ b/Sources/gh-pr-patrol/Environment.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+struct MultipleErrors: Error, CustomStringConvertible {
+
+    let description: String
+
+    init(messages: [String]) {
+        self.description = messages.joined(separator: "\n")
+    }
+}
+
+struct Environment: Decodable {
+
+    let ghRepo: String
+    let ghApiToken: String
+    let bitriseApiToken: String
+    let bitriseBuildTriggerToken: String
+    let appSlug: String
+
+    // Here we customize Decodable behavior,
+    // so we can report all missing environment variables to user at once.
+    // By default Decodable exits by the first error.
+    // We've got 5 required environment variable and the default behavior is not ergonomic.
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+
+        var msgs = [String]()
+
+        func decodeOrAppendError<T: Decodable>(_ type: T.Type, forKey key: CodingKeys) -> T? {
+
+            do {
+                return try values.decode(type, forKey: key)
+            } catch {
+                guard let decodingError = error as? DecodingError else {
+                    assertionFailure("Unexpected error: \(error)")
+                    return nil
+                }
+                switch decodingError {
+                case .dataCorrupted:
+                    msgs.append("data corrupted at \(key.stringValue)")
+                case .keyNotFound:
+                    msgs.append("env key not found: \(key.stringValue)")
+                case .typeMismatch(let actualType, _):
+                    msgs.append("type mismatch: expected \(type) but got \(actualType)")
+                case .valueNotFound(let actualType, _):
+                    msgs.append("value not found for \(key.stringValue) with type: \(actualType)")
+                }
+                return nil
+            }
+
+        }
+
+        let ghRepo = decodeOrAppendError(String.self, forKey: .ghRepo)
+        let ghApiToken = decodeOrAppendError(String.self, forKey: .ghApiToken)
+        let bitriseApiToken = decodeOrAppendError(String.self, forKey: .bitriseApiToken)
+        let bitriseBuildTriggerToken = decodeOrAppendError(String.self, forKey: .bitriseBuildTriggerToken)
+        let appSlug = decodeOrAppendError(String.self, forKey: .appSlug)
+
+        if !msgs.isEmpty {
+            throw MultipleErrors(messages: msgs)
+        }
+
+        self.ghRepo = ghRepo!
+        self.ghApiToken = ghApiToken!
+        self.bitriseApiToken = bitriseApiToken!
+        self.bitriseBuildTriggerToken = bitriseBuildTriggerToken!
+        self.appSlug = appSlug!
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case ghRepo = "GITHUB_REPOSITORY"
+        case ghApiToken = "GITHUB_ACCESS_TOKEN"
+        case bitriseApiToken = "BITRISE_API_TOKEN"
+        case bitriseBuildTriggerToken = "BITRISE_BUILD_TRIGGER_TOKEN"
+        case appSlug = "APP_SLUG"
+    }
+}

--- a/Sources/gh-pr-patrol/main.swift
+++ b/Sources/gh-pr-patrol/main.swift
@@ -34,31 +34,19 @@ struct TriggerBuildOrigin {
     let status: PRBuildStatus
 }
 
-// - MARK: Arguments and Environments
-
-struct Environment {
-    let ghRepo: String
-    let ghApiToken: String
-    let bitriseApiToken: String
-    let bitriseBuildTriggerToken: String
-    let appSlug: String
-
-    init(_ env: [String: String]) {
-        func getValue(_ key: String) -> String {
-            guard let value = env[key] else {
-                fatalError("Error: missing required environment variable: \(key)")
-            }
-            return value
-        }
-        ghRepo = getValue("GITHUB_REPOSITORY")
-        ghApiToken = getValue("GITHUB_ACCESS_TOKEN")
-        bitriseApiToken = getValue("BITRISE_API_TOKEN")
-        bitriseBuildTriggerToken = getValue("BITRISE_BUILD_TRIGGER_TOKEN")
-        appSlug = getValue("APP_SLUG")
+func tryOrExit<T>(_ closure: @autoclosure () throws -> T) -> T {
+    do {
+        return try closure()
+    } catch {
+        print("\(error)")
+        exit(0)
     }
 }
 
-let env = Environment(ProcessInfo.processInfo.environment)
+// - MARK: Arguments and Environments
+
+let data = try! JSONSerialization.data(withJSONObject: ProcessInfo.processInfo.environment, options: [])
+let env = tryOrExit(try JSONDecoder().decode(Environment.self, from: data))
 
 let ghRepo = env.ghRepo
 let appSlug = env.appSlug

--- a/Sources/gh-pr-patrol/main.swift
+++ b/Sources/gh-pr-patrol/main.swift
@@ -1,6 +1,7 @@
 // 1. Get the last and non-fresh builds for each PR open.
 // 2. Trigger re-build
 
+import Core
 import Foundation
 
 if ProcessInfo.processInfo.arguments.contains("-v") {
@@ -45,8 +46,7 @@ func tryOrExit<T>(_ closure: @autoclosure () throws -> T) -> T {
 
 // - MARK: Arguments and Environments
 
-let data = try! JSONSerialization.data(withJSONObject: ProcessInfo.processInfo.environment, options: [])
-let env = tryOrExit(try JSONDecoder().decode(Environment.self, from: data))
+let env = tryOrExit(try Environment.decode(ProcessInfo.processInfo.environment))
 
 let ghRepo = env.ghRepo
 let appSlug = env.appSlug

--- a/Tests/CoreTests/EnvironmentTests.swift
+++ b/Tests/CoreTests/EnvironmentTests.swift
@@ -1,0 +1,73 @@
+import Core
+import XCTest
+
+final class EnviornmentTests: XCTestCase {
+    func test_decode_error() {
+        let env = [String: String]()
+
+        do {
+            _ = try Environment.decode(env)
+            XCTFail("expected error thrown")
+        } catch {
+            guard let e = error as? MultipleErrors else {
+                XCTFail("unexpected error type")
+                return
+            }
+            XCTAssertEqual(e.description, """
+            env key not found: GITHUB_REPOSITORY
+            env key not found: GITHUB_ACCESS_TOKEN
+            env key not found: BITRISE_API_TOKEN
+            env key not found: BITRISE_BUILD_TRIGGER_TOKEN
+            env key not found: APP_SLUG
+            """)
+        }
+    }
+
+    func test_decode_fails_on_empty_strings() {
+        let env: [String: String] = [
+            "GITHUB_REPOSITORY": "",
+            "GITHUB_ACCESS_TOKEN": "",
+            "BITRISE_API_TOKEN": "",
+            "BITRISE_BUILD_TRIGGER_TOKEN": "",
+            "APP_SLUG": "",
+        ]
+
+        do {
+            _ = try Environment.decode(env)
+            XCTFail("expected error thrown")
+        } catch {
+            guard let e = error as? MultipleErrors else {
+                XCTFail("unexpected error type")
+                return
+            }
+            XCTAssertEqual(e.description, """
+            env value is empty: GITHUB_REPOSITORY
+            env value is empty: GITHUB_ACCESS_TOKEN
+            env value is empty: BITRISE_API_TOKEN
+            env value is empty: BITRISE_BUILD_TRIGGER_TOKEN
+            env value is empty: APP_SLUG
+            """)
+        }
+    }
+
+    func test_decode_success() {
+        let env: [String: String] = [
+            "GITHUB_REPOSITORY": "a",
+            "GITHUB_ACCESS_TOKEN": "b",
+            "BITRISE_API_TOKEN": "c",
+            "BITRISE_BUILD_TRIGGER_TOKEN": "d",
+            "APP_SLUG": "e",
+        ]
+
+        do {
+            let environment = try Environment.decode(env)
+            XCTAssertEqual(environment.ghRepo, "a")
+            XCTAssertEqual(environment.ghApiToken, "b")
+            XCTAssertEqual(environment.bitriseApiToken, "c")
+            XCTAssertEqual(environment.bitriseBuildTriggerToken, "d")
+            XCTAssertEqual(environment.appSlug, "e")
+        } catch {
+            XCTFail("unexpected error thrown: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
```
    // Here we customize Decodable behavior,
    // so we can report all missing environment variables to user at once.
    // By default Decodable exits by the first error.
    // We've got 5 required environment variable and the default behavior is not ergonomic.
```

<img width="835" alt="screen shot 2019-03-08 at 21 21 02" src="https://user-images.githubusercontent.com/6007952/54028799-984ed780-41e9-11e9-808b-bcafcc89ee6d.png">
